### PR TITLE
Added overloads to support token credentials

### DIFF
--- a/Rebus.AzureBlobs/Config/AzureBlobsDataBusStorageConfigurationExtensions.cs
+++ b/Rebus.AzureBlobs/Config/AzureBlobsDataBusStorageConfigurationExtensions.cs
@@ -4,6 +4,7 @@ using Rebus.Logging;
 using System;
 using Azure.Storage.Blobs;
 using Rebus.Time;
+using Azure.Core;
 // ReSharper disable UnusedMember.Global
 
 namespace Rebus.Config;
@@ -36,6 +37,20 @@ public static class AzureBlobsDataBusStorageConfigurationExtensions
         if (containerUri == null) throw new ArgumentNullException(nameof(containerUri));
 
         var blobContainerClient = new BlobContainerClient(containerUri);
+
+        return Configure(configurer, blobContainerClient);
+    }
+
+    /// <summary>
+    /// Configures Rebus' data bus to store data in/read data from Azure blobs in the blob container with the given <paramref name="containerUri"/> and <paramref name="credentials"/>
+    /// </summary>
+    public static AzureBlobsDataBusStorageOptions StoreInBlobStorage(this StandardConfigurer<IDataBusStorage> configurer, Uri containerUri, TokenCredential credentials)
+    {
+        if (configurer == null) throw new ArgumentNullException(nameof(configurer));
+        if (containerUri == null) throw new ArgumentNullException(nameof(containerUri));
+        if (credentials == null) throw new ArgumentNullException(nameof(credentials));
+
+        var blobContainerClient = new BlobContainerClient(containerUri, credentials);
 
         return Configure(configurer, blobContainerClient);
     }

--- a/Rebus.AzureBlobs/Config/AzureBlobsErrorTrackerConfigurationExtensions.cs
+++ b/Rebus.AzureBlobs/Config/AzureBlobsErrorTrackerConfigurationExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Azure.Core;
 using Azure.Storage.Blobs;
 using Rebus.AzureBlobs.Retries;
 using Rebus.Retry;
@@ -9,6 +10,9 @@ namespace Rebus.Config;
 
 public static class AzureBlobsErrorTrackerConfigurationExtensions
 {
+    /// <summary>
+    /// Configures Rebus to use blob storage for storing tracking errors
+    /// </summary>
     public static void UseBlobStorageErrorTracker(this StandardConfigurer<IErrorTracker> configurer, string connectionString, string containerName)
     {
         if (configurer == null) throw new ArgumentNullException(nameof(configurer));
@@ -18,6 +22,25 @@ public static class AzureBlobsErrorTrackerConfigurationExtensions
         configurer.Register(c =>
         {
             var blobContainerClient = new BlobContainerClient(connectionString, containerName);
+            var retryStrategySettings = c.Get<RetryStrategySettings>();
+            var transport = c.Get<ITransport>();
+            var exceptionLogger = c.Get<IExceptionLogger>();
+            return new AzureBlobsErrorTracker(blobContainerClient, retryStrategySettings, transport, exceptionLogger);
+        });
+    }
+
+    /// <summary>
+    /// Configures Rebus to use blob storage for storing tracking errors
+    /// </summary>
+    public static void UseBlobStorageErrorTracker(this StandardConfigurer<IErrorTracker> configurer, Uri containerUri, TokenCredential credentials)
+    {
+        if (configurer == null) throw new ArgumentNullException(nameof(configurer));
+        if (containerUri == null) throw new ArgumentNullException(nameof(containerUri));
+        if (credentials == null) throw new ArgumentNullException(nameof(credentials));
+
+        configurer.Register(c =>
+        {
+            var blobContainerClient = new BlobContainerClient(containerUri, credentials);
             var retryStrategySettings = c.Get<RetryStrategySettings>();
             var transport = c.Get<ITransport>();
             var exceptionLogger = c.Get<IExceptionLogger>();

--- a/Rebus.AzureBlobs/Config/AzureStorageSagaConfigurationExtensions.cs
+++ b/Rebus.AzureBlobs/Config/AzureStorageSagaConfigurationExtensions.cs
@@ -3,6 +3,7 @@ using Rebus.AzureBlobs.Sagas;
 using Rebus.Logging;
 using System;
 using Azure.Storage.Blobs;
+using Azure.Core;
 
 // ReSharper disable UnusedMember.Global
 
@@ -23,6 +24,20 @@ public static class AzureStorageSagaConfigurationExtensions
         if (containerName == null) throw new ArgumentNullException(nameof(containerName));
 
         var blobContainerClient = new BlobContainerClient(storageAccountConnectionString, containerName);
+
+        configurer.Register(c => new AzureStorageSagaSnapshotStorage(blobContainerClient, c.Get<IRebusLoggerFactory>()));
+    }
+
+    /// <summary>
+    /// Configures Rebus to store saga data snapshots in blob storage
+    /// </summary>
+    public static void StoreInBlobStorage(this StandardConfigurer<ISagaSnapshotStorage> configurer, Uri containerUri, TokenCredential credentials)
+    {
+        if (configurer == null) throw new ArgumentNullException(nameof(configurer));
+        if (containerUri == null) throw new ArgumentNullException(nameof(containerUri));
+        if (credentials == null) throw new ArgumentNullException(nameof(credentials));
+
+        var blobContainerClient = new BlobContainerClient(containerUri, credentials);
 
         configurer.Register(c => new AzureStorageSagaSnapshotStorage(blobContainerClient, c.Get<IRebusLoggerFactory>()));
     }


### PR DESCRIPTION
Hey there. This is related to this issue - https://github.com/rebus-org/Rebus.AzureBlobs/issues/7

Hope you can merge it, any questions let me know?

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
